### PR TITLE
local run fixups

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "webpack --config webpack/webpack.prod.js",
     "bundle": "npm run build",
-    "startDev": "webpack --config webpack/webpack.dev.js --watch & NODE_ENV=development node src/server/server.ts & node_modules/open-cli/cli.js http://localhost:3000",
+    "startDev": "./run_local.sh",
     "startProd": "NODE_ENV=production node src/server/server.ts",
     "lint": "eslint . --ext .ts"
   },

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,12 @@
+set -e # exit if anything errors
+
+./node_modules/.bin/webpack --config webpack/webpack.dev.js --watch &
+P1=$!
+
+NODE_ENV=development node src/server/server.ts &
+P2=$!
+
+node_modules/open-cli/cli.js http://localhost:3000 &
+P3=$!
+
+wait $P1 $P2 $P3

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -19,7 +19,11 @@ const playerId = 0;
 app.use("/", express.static(path.join(__dirname, "../../dist")));
 
 app.get("/", (req, res) => {
-  res.sendFile(path.join(__dirname, "../../dist/index.html"));
+  if (process.env.NODE_ENV == "production") {
+    res.sendFile(path.join(__dirname, "../../dist/index.html"));
+  } else {
+    res.sendFile(path.join(__dirname, "../index.html"));
+  }
 });
 
 app.get("/port", (req, res) => {


### PR DESCRIPTION
1. run all processes within a script, so if you press ctrl+c they all
exist (previously, some zombie processes were left running)
2. change dev mode to serve index.html from src instead of dist. If you
haven't run `npm build`, `npm run startDev` doesn't work because no file
exists at `dist/index.html`