### PR TITLE
Move typescript to prod dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11180,10 +11180,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
-      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
-      "dev": true
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "open-cli": "^6.0.1",
     "prettier": "2.0.5",
     "ts-loader": "^5.4.5",
-    "typescript": "^3.9.6",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0",
@@ -68,7 +67,8 @@
     "phaser3-rex-plugins": "^1.1.23",
     "socket.io": "^2.3.0",
     "socket.io-client": "^2.3.0",
-    "ts-node": "^8.10.2"
+    "ts-node": "^8.10.2",
+    "typescript": "^3.9.7"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Since we're using ts-node, we need to move it to prod dependency.