### PR TITLE
Count votes and display

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -194,6 +194,11 @@ io.on("connection", (socket) => {
   // We should actually track who voted for whom so we can actually change votes
   socket.on("vote", (data) => {
     votes[data.votedID] ? votes[data.votedID]++ : (votes[data.votedID] = 1);
+    const maxVotePlayerID = _.maxBy(Object.keys(votes), (key) => votes[key]);
+    io.to(roomName).emit("winningVote", {
+      playerID: maxVotePlayerID,
+      votes: votes[maxVotePlayerID],
+    });
   });
 
   ////////////////


### PR DESCRIPTION
Support voting and display player with most votes. Ties are currently handled by taking whoever was voted first rather than who was voted first at that number. Example:

Bob: 2 votes
Alice: 3 votes
Alice is emitted as player with leading votes
---> 
Bob: 3 votes
Alice: 3 votes
Bob is emitted as player with leading votes even though it's a tie and Alice hit 3 votes first

--------

I'd like to do some refactoring and introducing some better UI. Ideally the voting mechanism would be tied to the active clues table but it turned out to be a bigger task than I set aside time to do and that's why it's just a copy+paste of the icon + dialog combo.