### PR TITLE
Bugfix nextscene

### DIFF
--- a/src/server/lib/core.ts
+++ b/src/server/lib/core.ts
@@ -84,13 +84,17 @@ const registerListeners = (
 
   socket.on(E.NextScene, () => {
     // Remove listeners for current scene
-    sceneHandlers(io, socket, gameState.getScene()).teardown(gameState);
+    Object.values(io.sockets.in(gameState.room).sockets).forEach((s) => {
+      sceneHandlers(io, s, gameState.getScene()).teardown(gameState);
+    });
 
     // Update game state
     gameState.advanceScene();
 
     // Add listeners for new scene
-    sceneHandlers(io, socket, gameState.getScene()).setup(gameState);
+    Object.values(io.sockets.in(gameState.room).sockets).forEach((s) => {
+      sceneHandlers(io, s, gameState.getScene()).setup(gameState);
+    });
 
     // Emit event
     io.to(gameState.room).emit(E.ChangeScene, <EType[E.ChangeScene]>{

--- a/src/server/lib/core.ts
+++ b/src/server/lib/core.ts
@@ -41,7 +41,7 @@ const handlePlayerJoined = (
     };
   }
 
-  io.to(socket.id).emit(E.ChangeScene, <EType[E.ChangeScene]>{
+  socket.emit(E.ChangeScene, <EType[E.ChangeScene]>{
     sceneKey: gameState.getScene(),
   });
   syncClientGameState(io, gameState);

--- a/src/server/lib/scenes/game.ts
+++ b/src/server/lib/scenes/game.ts
@@ -16,14 +16,13 @@ const registerListeners = (
     syncClientGameState(io, gameState);
   });
 
-  // This voting system is like Medium, you can vote as many times as you'd like
-  // We should actually track who voted for whom so we can actually change votes
   socket.on(E.Vote, (data: EType[E.Vote]) => {
     const playerID = gameState.getPlayerIDFromName(data.votedName);
     if (!playerID) {
       // ignore vote if there's no player with that name
       return;
     }
+    // TODO: disallow voting if there's not a clue yet from that player
 
     gameState.vote(data.senderID, playerID);
 

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -7,7 +7,6 @@ export enum E {
   // General
   SyncGameState = "syncGameState",
   ChangeScene = "changeScene", // when a new scene should be loaded by all clients
-  // TODO: Could replace ServeReady if sent to just new client
 
   /* Events sent by Clients */
   // General


### PR DESCRIPTION
see fc609ea for the main fix. other commits are just cleanup

NextScene should add handlers for _all_ sockets

Previously, only the player who had clicked NextScene was able to take
actions like "Give Clue", because the Server had only setup listeners
for that one socket. It was possible to workaround this by having other
players refresh the page. This change makes that unnecessary.