### PR TITLE
Improve ux of stands

### DIFF
--- a/src/client/scripts/lib/discuss.ts
+++ b/src/client/scripts/lib/discuss.ts
@@ -1,5 +1,6 @@
 import * as models from "../../../shared/models";
 import { E, EType } from "../../../shared/events";
+import { WildcardStand, WildcardPlayerID } from "../../../shared/constants";
 
 // if false, clue is not valid
 export const giveClue = (
@@ -34,7 +35,7 @@ const generateClue = (
     const s = getBestStand(gameState, c);
 
     // wild card case
-    if (s.playerType == models.PlayerType.Wildcard) {
+    if (s.playerID == WildcardPlayerID) {
       if (wildcardLetter != "" && wildcardLetter != c) {
         // Wildcard can only be used for one letter
         return false;
@@ -59,24 +60,7 @@ const getBestStand = (
     }
   }
 
-  return {
-    player: "wildcard",
-    playerType: models.PlayerType.Wildcard,
-    letter: models.Letter.Wildcard,
-  };
-};
-
-// Helper function to separate visible letters by type of player
-const getLettersByPlayerType = (gameState: models.ClientGameState) => {
-  const playerTypeLetters = {
-    [models.PlayerType.Player]: [],
-    [models.PlayerType.NPC]: [],
-    [models.PlayerType.Bonus]: [],
-  };
-  for (const stand of gameState.visibleLetters) {
-    playerTypeLetters[stand.playerType].push(stand.letter);
-  }
-  return playerTypeLetters;
+  return WildcardStand;
 };
 
 // Send vote to server. PlayerID can be accessed from clue

--- a/src/client/scripts/objects/activeClues.ts
+++ b/src/client/scripts/objects/activeClues.ts
@@ -51,7 +51,7 @@ export default class ActiveClues extends Phaser.GameObjects.Container {
     const wordLength = clue.word.length;
     const counts = _.countBy(
       _.uniq(clue.assignedStands),
-      (s: Stand) => s.playerType
+      (s: Stand) => this.scene.gameState.players[s.playerID]
     );
 
     const playerName = this.scene.gameState.players[playerID].Name;

--- a/src/client/scripts/objects/activeClues.ts
+++ b/src/client/scripts/objects/activeClues.ts
@@ -1,6 +1,7 @@
 import * as _ from "lodash";
-import { Clue, ClueV2, Stand, PlayerType } from "../../../shared/models";
+import * as models from "../../../shared/models";
 import GameScene from "../scenes/gameScene";
+import { WildcardPlayerID } from "../../../shared/constants";
 
 const headers = [
   "Player       ",
@@ -47,21 +48,31 @@ export default class ActiveClues extends Phaser.GameObjects.Container {
     scene.add.existing(this);
   }
 
-  clueToArray = (playerID: string, clue: ClueV2): string[] => {
+  getPlayerType = (gameState: models.ClientGameState, playerID: string) => {
+    if (gameState.players[playerID]) {
+      return models.PlayerType.Player;
+    } else if (playerID == WildcardPlayerID) {
+      return models.PlayerType.Wildcard;
+    } else {
+      return models.PlayerType.NPC;
+    }
+  };
+
+  clueToArray = (playerID: string, clue: models.ClueV2): string[] => {
     const wordLength = clue.word.length;
-    const counts = _.countBy(
-      _.uniq(clue.assignedStands),
-      (s: Stand) => this.scene.gameState.players[s.playerID]
+    console.log({ clue });
+    const counts = _.countBy(_.uniq(clue.assignedStands), (s: models.Stand) =>
+      this.getPlayerType(this.scene.gameState, s.playerID)
     );
 
     const playerName = this.scene.gameState.players[playerID].Name;
     const out = [
       playerName,
       `${wordLength}`,
-      `${counts[PlayerType.Player] || 0}`,
-      `${counts[PlayerType.NPC] || 0}`,
-      `${counts[PlayerType.Bonus] || 0}`,
-      `${counts[PlayerType.Wildcard] ? "Y" : "N"}`,
+      `${counts[models.PlayerType.Player] || 0}`,
+      `${counts[models.PlayerType.NPC] || 0}`,
+      `${counts[models.PlayerType.Bonus] || 0}`,
+      `${counts[models.PlayerType.Wildcard] ? "Y" : "N"}`,
       `${this.scene.gameState.votes[playerID] || 0}`,
     ];
 

--- a/src/client/scripts/scenes/gameScene.ts
+++ b/src/client/scripts/scenes/gameScene.ts
@@ -7,7 +7,11 @@ import ActiveClues from "../objects/activeClues";
 import Dialog from "../objects/dialog";
 import { giveClue, vote } from "../lib/discuss";
 
-import { PlayStateEnum, SceneEnum } from "../../../shared/constants";
+import {
+  PlayStateEnum,
+  SceneEnum,
+  WildcardPlayerName,
+} from "../../../shared/constants";
 import { ClientGameState, Stand, Letter } from "../../../shared/models";
 import { E } from "../../../shared/events";
 
@@ -76,7 +80,7 @@ export default class GameScene extends Phaser.Scene {
       return player.Name; // Player
     }
 
-    return s.playerID.replace("N", "NPC "); // NPC
+    return s.playerID; // NPC or wildcard
   }
 
   _drawVisibleLetters = (): void => {
@@ -128,7 +132,7 @@ export default class GameScene extends Phaser.Scene {
     const label = this.add.text(
       X_OFFSET + WIDTH * lastIdx,
       Y_OFFSET + 80,
-      "Wild",
+      WildcardPlayerName,
       styleMedium
     );
     const counter = this.add.text(

--- a/src/server/lib/gameState.ts
+++ b/src/server/lib/gameState.ts
@@ -18,6 +18,8 @@ import {
   Scenes,
   PlayStates,
   PlayStateEnum,
+  NPCPlayerIDPrefix,
+  WildcardPlayerID,
 } from "../../shared/constants";
 
 // TODO: How to persist this across server restarts
@@ -183,13 +185,15 @@ export class ServerGameState {
     });
   }
 
-  getPlayerType(playerID: string) {
+  getPlayerType = (playerID: string) => {
     if (this.players[playerID]) {
       return PlayerType.Player;
+    } else if (playerID == WildcardPlayerID) {
+      return PlayerType.Wildcard;
     } else {
       return PlayerType.NPC;
     }
-  }
+  };
 
   takeTurnToken(playerID: string) {
     // TODO: This logic is simplified. It needs to be updated
@@ -295,7 +299,7 @@ export class ServerGameState {
       this.visibleLetterIdx[key] = 0;
     }
     for (let i = 0; i < this.numNPCs; i++) {
-      this.visibleLetterIdx[`N${i + 1}`] = 0;
+      this.visibleLetterIdx[`${NPCPlayerIDPrefix}${i + 1}`] = 0;
     }
 
     // initialize guessingSheets
@@ -389,7 +393,10 @@ const drawCards = (playerIDs: string[]) => {
 
   // Take the remaining letters to populate NPC hands
   for (let i = 0; i < MaxPlayers - playerIDs.length; i++) {
-    npcHands[`N${i + 1}`] = deck.splice(0, BaseNPCCards + NPCCardGrowth * i);
+    npcHands[`${NPCPlayerIDPrefix}${i + 1}`] = deck.splice(
+      0,
+      BaseNPCCards + NPCCardGrowth * i
+    );
   }
 
   return {

--- a/src/server/lib/scenes/game.ts
+++ b/src/server/lib/scenes/game.ts
@@ -51,7 +51,6 @@ const deregisterListeners = (
   socket: SocketIO.Socket,
   gameState: ServerGameState
 ) => {
-  socket.removeAllListeners(E.GetVisibleLetters);
   socket.removeAllListeners(E.UpdateClue);
   socket.removeAllListeners(E.Vote);
   socket.removeAllListeners(E.NextVisibleLetter);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -79,6 +79,9 @@ export const BaseNPCCards = 7;
 export const NPCCardGrowth = 1;
 export const MaxPlayers = 6;
 export const DefaultPlayerName = "Default Player Name";
+export const NPCPlayerIDPrefix = "NPC ";
+export const WildcardPlayerID = "Wildcard";
+export const WildcardPlayerName = "Wild";
 
 export enum SceneEnum {
   LobbyScene = "LobbyScene",
@@ -107,3 +110,10 @@ export const PlayStates = [
   PlayStateEnum.INTERPRET_HINT,
   PlayStateEnum.CHECK_END_CONDITION,
 ];
+
+export const WildcardStand = {
+  playerID: WildcardPlayerID,
+  letter: Letter.Wildcard,
+  currentCardIdx: 1,
+  totalCards: 1,
+};

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -18,7 +18,6 @@ export enum E {
   SetPlayerName = "setPlayerName",
 
   // GameScene
-  GetVisibleLetters = "getVisibleLetters",
   ChangePlayState = "changePlayState",
   NextVisibleLetter = "nextVisibleLetter",
   UpdateClue = "updateClue",

--- a/src/shared/models.ts
+++ b/src/shared/models.ts
@@ -4,9 +4,10 @@ import { ServerGameState } from "../server/lib/gameState";
 import e from "express";
 
 export type Stand = {
-  player: string;
-  playerType: PlayerType;
+  playerID: string;
   letter: Letter;
+  currentCardIdx: number;
+  totalCards: number;
 };
 
 // No J, Q, V, X, or Z
@@ -33,6 +34,7 @@ export enum Letter {
   W = "w",
   Y = "y",
   Wildcard = "*",
+  Hidden = "?",
 }
 
 export type PlayerProperties = {


### PR DESCRIPTION
https://trello.com/c/MygLXsSe/120-show-of-cards-remaining-per-stand

Now looks like:
![image](https://user-images.githubusercontent.com/102242/92697167-c5f56f00-f2ff-11ea-9aba-c223476ddac3.png)

Changes:

1. player name improvements and new cards
  - ? for current player
  - * for wildcard
  - NPCs labeled with NPC number instead of N number
2. progress through a given stack (e.g. card 2 of 5)
3. large font for current letter, smaller font for details
4. (internals) progress toward playerID for all matching / lookups, instead of player name