### PR TITLE
Reduce cpu usage ?

### DIFF
--- a/src/client/scripts/scenes/gameScene.ts
+++ b/src/client/scripts/scenes/gameScene.ts
@@ -37,28 +37,6 @@ export default class GameScene extends Phaser.Scene {
   constructor() {
     super({ key });
     this.board = [];
-
-    this.dialog = new Dialog(
-      this,
-      "Enter clue here",
-      "What is your clue?",
-      null,
-      (content: string) => {
-        const validClue = giveClue(this.socket, content, this.gameState);
-        if (!validClue) {
-          // Let user know and prompt for another clue
-        }
-      }
-    );
-    this.voteDialog = new Dialog(
-      this,
-      " ",
-      "Who are you voting for?",
-      null,
-      (votedName: string) => {
-        vote(this.socket, this.gameState.playerID, votedName);
-      }
-    );
   }
 
   init({ socket, gameState }): void {
@@ -164,6 +142,29 @@ export default class GameScene extends Phaser.Scene {
 
   create(): void {
     this.gameState = this.registry.get("gameState");
+
+    // Dialogs
+    this.dialog = new Dialog(
+      this,
+      "Enter clue here",
+      "What is your clue?",
+      null,
+      (content: string) => {
+        const validClue = giveClue(this.socket, content, this.gameState);
+        if (!validClue) {
+          // Let user know and prompt for another clue
+        }
+      }
+    );
+    this.voteDialog = new Dialog(
+      this,
+      " ",
+      "Who are you voting for?",
+      null,
+      (votedName: string) => {
+        vote(this.socket, this.gameState.playerID, votedName);
+      }
+    );
 
     // Scene title
     this.add.text(0, 0, `${key}`, {


### PR DESCRIPTION
I've noticed that the gameScene sometimes spikes to high CPU usage for me. My hypothesis is that creating/deleting gameObjects repeatedly in the `update()` loop is expensive.

We now initialize the stands once in `create()`, and only `setText` in the `update()` loop.

Locally, this seems to make a difference in my CPU, but I haven't done any rigorous testing.