### PR TITLE
Support footer and guessing on guessing sheet

### DIFF
--- a/src/client/scripts/objects/guessingSheet.ts
+++ b/src/client/scripts/objects/guessingSheet.ts
@@ -1,16 +1,40 @@
 import * as _ from "lodash";
+import { COLOR_HOVER, COLOR_SECONDARY } from "../../../shared/constants";
 import { Table } from "../objects/table";
 
 export default class GuessingSheet extends Phaser.GameObjects.Container {
   table: Table;
 
-  constructor(scene: Phaser.Scene) {
+  constructor(scene) {
     super(scene, 0, 0);
+
+    const numColumns = 10;
+    const cellOver = function (cellContainer, cellIndex, pointer) {
+      if (cellIndex > numColumns && cellIndex % numColumns === numColumns - 1) {
+        cellContainer.getElement("background").setFillStyle(2, COLOR_SECONDARY);
+      }
+    };
+    const cellOut = function (cellContainer, cellIndex, pointer) {
+      if (cellIndex > numColumns && cellIndex % numColumns === numColumns - 1) {
+        cellContainer.getElement("background").setFillStyle(2, COLOR_HOVER);
+      }
+    };
+    const cellClick = function (cellContainer, cellIndex, pointer) {
+      if (cellIndex > numColumns && cellIndex % numColumns === numColumns - 1) {
+        const edit = this.scene.rexUI.edit(cellContainer.getElement("text"));
+        edit.open({}, (textObject) => {
+          this.overrideValues[cellIndex] = {
+            text: textObject.text,
+            keep: true,
+          };
+        });
+      }
+    };
     this.table = new Table(
       scene,
       {
         title: "Guessing Sheet",
-        numColumns: 10,
+        numColumns,
         headerRow: [
           { text: "1" },
           { text: "2" },
@@ -23,8 +47,27 @@ export default class GuessingSheet extends Phaser.GameObjects.Container {
           { text: "9..." },
           { text: "???" },
         ],
+        height: 550,
+        y: 400,
+        footer: () =>
+          scene.rexUI.add
+            .BBCodeText(400, 300, " ", {
+              color: "white",
+              fontSize: "24px",
+              fixedWidth: 200,
+              backgroundColor: "#333333",
+            })
+            .setOrigin(0.5)
+            .setInteractive()
+            .on("pointerdown", function () {
+              this.scene.rexUI.edit(this);
+            }),
       },
-      {}
+      {
+        cellOver,
+        cellOut,
+        cellClick,
+      }
     );
     this.table.create();
   }


### PR DESCRIPTION
* Allow guessing in the footer of the guessing table for the final word
* Allow guessing at end of row for letter clues

TODO: need to push this to server to keep track of player's own guesses to preserve after browser refresh.