### PR TITLE
Handle finishing NPC stacks

### DIFF
--- a/src/server/lib/gameState.ts
+++ b/src/server/lib/gameState.ts
@@ -215,6 +215,13 @@ export class ServerGameState {
     );
     npcStands.forEach((s: Stand) => {
       this.visibleLetterIdx[s.playerID] += 1;
+      if (
+        this.visibleLetterIdx[s.playerID] ==
+        this.letters[s.playerID].length - 1
+      ) {
+        // When the last card in NPC stack is drawn, earn a green clue token
+        this.flower.green += 1;
+      }
     });
   }
 

--- a/src/server/lib/gameState.ts
+++ b/src/server/lib/gameState.ts
@@ -215,12 +215,21 @@ export class ServerGameState {
     );
     npcStands.forEach((s: Stand) => {
       this.visibleLetterIdx[s.playerID] += 1;
+
+      // When the last card in NPC stack is drawn, earn a green clue token
       if (
         this.visibleLetterIdx[s.playerID] ==
         this.letters[s.playerID].length - 1
       ) {
-        // When the last card in NPC stack is drawn, earn a green clue token
         this.flower.green += 1;
+      }
+
+      // Once its stack is empty, the nonplayer stand draws its new cards from the deck
+      if (
+        this.visibleLetterIdx[s.playerID] >
+        this.letters[s.playerID].length - 1
+      ) {
+        this.letters[s.playerID].push(this.drawCardFromDeck());
       }
     });
   }
@@ -420,6 +429,10 @@ export class ServerGameState {
       flower: this.flower,
       playersReady: this.playersReady,
     };
+  }
+
+  drawCardFromDeck(): Letter {
+    return this.deck.pop();
   }
 }
 


### PR DESCRIPTION
https://trello.com/c/x51VmU7z/136-handle-finishing-npc-stack

- earn clue token from NPC stack
- when NPC stack finished, draw from deck

The logic works, though the UI is a little off. It will show the deck growing each time a card is drawn ... 7/7 -> 8/8.
Since we may solve the UI some other way, I'm ignoring that for now.

